### PR TITLE
feat: 新增配置文件，控制获取面板图列表时每个转发消息中的面板图数量，优化部分类型不一致问题

### DIFF
--- a/XutheringWavesUID/utils/api/request_util.py
+++ b/XutheringWavesUID/utils/api/request_util.py
@@ -39,7 +39,7 @@ async def get_base_header(devCode: Optional[str] = None):
     return header
 
 
-async def get_community_header():
+async def get_community_header() -> dict[str, str]:
     devCode = generate_random_string()
     header = await get_base_header(devCode)
     header["source"] = "h5"

--- a/XutheringWavesUID/utils/calc/__init__.py
+++ b/XutheringWavesUID/utils/calc/__init__.py
@@ -56,7 +56,7 @@ class WuWaCalc(object):
         # 声骸面板数据
         self.phantom_card = {}
         # 角色评分使用
-        self.calc_temp = None
+        self.calc_temp: dict[Any, Any] = {}
         # 角色面板数据
         self.role_card = {}
         # attr

--- a/XutheringWavesUID/utils/image.py
+++ b/XutheringWavesUID/utils/image.py
@@ -286,7 +286,7 @@ async def get_qq_avatar(
         avatar_url = f"http://q1.qlogo.cn/g?b=qq&nk={qid}&s={size}"
     elif avatar_url is None:
         # avatar_url = f"https://q1.qlogo.cn/g?b=qq&nk=3399214199&s={size}"
-        return None
+        return Image.new("RGBA", (size, size), (255, 255, 255, 0))
     char_pic = Image.open(BytesIO((await sget(avatar_url)).content)).convert("RGBA")
     return char_pic
 

--- a/XutheringWavesUID/utils/util.py
+++ b/XutheringWavesUID/utils/util.py
@@ -186,12 +186,8 @@ def format_with_defaults(desc: str, params: List[Any], default_value: str = "N/A
     return desc.format(*params_list)
 
 
-def get_version(dynamic: bool = False, **kwargs):
+def get_version(**kwargs):
     from ..version import XutheringWavesUID_version
-    if dynamic:
-        from ..utils.safety import generate_dynamic_version
-        dynamic_version = generate_dynamic_version(**kwargs)
-        return XutheringWavesUID_version + dynamic_version
 
     return XutheringWavesUID_version
 

--- a/XutheringWavesUID/wutheringwaves_alias/__init__.py
+++ b/XutheringWavesUID/wutheringwaves_alias/__init__.py
@@ -18,6 +18,8 @@ sv_list_char_alias = SV("ww角色名别名列表")
 )
 async def handle_add_char_alias(bot: Bot, ev: Event):
     action = ev.regex_dict.get("action")
+    if action not in ["添加", "删除"]:
+        return
     char_name = ev.regex_dict.get("name")
     new_alias = ev.regex_dict.get("new_alias")
     if not char_name or not new_alias:

--- a/XutheringWavesUID/wutheringwaves_charinfo/__init__.py
+++ b/XutheringWavesUID/wutheringwaves_charinfo/__init__.py
@@ -48,7 +48,7 @@ async def upload_char_img(bot: Bot, ev: Event):
     char = ev.regex_dict.get("char")
     if not char:
         return
-    await upload_custom_card(bot, ev, char, target_type=TYPE_MAP.get(ev.regex_dict.get("type"), "card"))
+    await upload_custom_card(bot, ev, char, target_type=TYPE_MAP.get(ev.regex_dict.get("type") or "", "card"))
 
 
 @waves_char_card_list.on_regex(rf"^(?P<char>{PATTERN})(?P<type>面板|面包|🍞|体力|背景)图列表$", block=True)
@@ -56,7 +56,7 @@ async def get_char_card_list(bot: Bot, ev: Event):
     char = ev.regex_dict.get("char")
     if not char:
         return
-    await get_custom_card_list(bot, ev, char, target_type=TYPE_MAP.get(ev.regex_dict.get("type"), "card"))
+    await get_custom_card_list(bot, ev, char, target_type=TYPE_MAP.get(ev.regex_dict.get("type") or "", "card"))
 
 
 @waves_delete_char_card.on_regex(
@@ -67,7 +67,7 @@ async def delete_char_card(bot: Bot, ev: Event):
     hash_id = ev.regex_dict.get("hash_id")
     if not char or not hash_id:
         return
-    await delete_custom_card(bot, ev, char, hash_id, target_type=TYPE_MAP.get(ev.regex_dict.get("type"), "card"))
+    await delete_custom_card(bot, ev, char, hash_id, target_type=TYPE_MAP.get(ev.regex_dict.get("type") or "", "card"))
 
 
 @waves_delete_all_card.on_regex(rf"^删除全部(?P<char>{PATTERN})(?P<type>面板|面包|🍞|体力|背景)图$", block=True)
@@ -75,7 +75,7 @@ async def delete_all_char_card(bot: Bot, ev: Event):
     char = ev.regex_dict.get("char")
     if not char:
         return
-    await delete_all_custom_card(bot, ev, char, target_type=TYPE_MAP.get(ev.regex_dict.get("type"), "card"))
+    await delete_all_custom_card(bot, ev, char, target_type=TYPE_MAP.get(ev.regex_dict.get("type") or "", "card"))
 
 
 @waves_compress_card.on_fullmatch(("压缩面板图", "压缩面包图", "压缩🍞图", "压缩背景图", "压缩体力图"), block=True)

--- a/XutheringWavesUID/wutheringwaves_charinfo/upload_card.py
+++ b/XutheringWavesUID/wutheringwaves_charinfo/upload_card.py
@@ -1,24 +1,27 @@
-import asyncio
-import hashlib
-import shutil
+import os
 import ssl
 import time
-import os
-from typing import List, Optional
+import shutil
+import asyncio
+import hashlib
+from typing import Any, List, Optional
 from concurrent.futures import ThreadPoolExecutor, as_completed
 
 import httpx
-
 from gsuid_core.bot import Bot
-from gsuid_core.logger import logger
 from gsuid_core.models import Event
-from gsuid_core.utils.download_resource.download_file import download
+from gsuid_core.logger import logger
 from gsuid_core.utils.image.convert import convert_img
+from gsuid_core.utils.download_resource.download_file import download
 
 from ..utils.image import compress_to_webp
-from ..utils.name_convert import alias_to_char_name, char_name_to_char_id
 from ..utils.resource.constant import SPECIAL_CHAR, SPECIAL_CHAR_ID
-from ..utils.resource.RESOURCE_PATH import CUSTOM_CARD_PATH, CUSTOM_MR_CARD_PATH, CUSTOM_MR_BG_PATH
+from ..utils.name_convert import alias_to_char_name, char_name_to_char_id
+from ..utils.resource.RESOURCE_PATH import (
+    CUSTOM_CARD_PATH,
+    CUSTOM_MR_BG_PATH,
+    CUSTOM_MR_CARD_PATH,
+)
 
 CUSTOM_PATH_MAP = {
     "card": CUSTOM_CARD_PATH,
@@ -151,9 +154,19 @@ async def get_custom_card_list(bot: Bot, ev: Event, char: str, target_type: str 
         imgs.append(f"{char}{target_type}图id : {hash_id}")
         imgs.append(img)
 
-    # imgs 5个一组
-    for i in range(0, len(imgs), 10):
-        send = imgs[i : i + 10]
+    # imgs 10个一组
+    from ..wutheringwaves_config import WutheringWavesConfig
+    card_num = WutheringWavesConfig.get_config("CharCardNum").data
+    # 转数字
+    if card_num is None:
+        card_num = 5
+    else:
+        card_num = int(card_num)
+    for i in range(0, len(imgs), card_num*2):
+        if len(imgs) < i+card_num*2:
+            send: list[Any] = imgs[i : len(imgs)]
+        else:
+            send = imgs[i : i+card_num*2]   
         await bot.send(send)
         await asyncio.sleep(0.5)
 
@@ -220,7 +233,10 @@ async def delete_all_custom_card(bot: Bot, ev: Event, char: str, target_type: st
 
 async def compress_all_custom_card(bot: Bot, ev: Event):
     count = 0
-    use_cores = max(os.cpu_count() - 2, 1) # 避免2c服务器卡死
+    cpus = os.cpu_count()
+    if cpus is None:
+        cpus = 1
+    use_cores = max(cpus - 2, 1) # 避免2c服务器卡死
     await bot.send(f"[鸣潮] 开始压缩面板、体力、背景图, 使用 {use_cores} 核心")
     
     task_list = []

--- a/XutheringWavesUID/wutheringwaves_charlist/__init__.py
+++ b/XutheringWavesUID/wutheringwaves_charlist/__init__.py
@@ -38,7 +38,7 @@ async def send_char_list_msg_new(bot: Bot, ev: Event):
             return await bot.send("请输入正确的查询特征码")
 
     user_id = ruser_id(ev)
-    user_waves_id = await WavesBind.get_uid_by_game(user_id, ev.bot_id)
+    user_waves_id = await WavesBind.get_uid_by_game(user_id, ev.bot_id) or ""
     if not query_waves_id:
         query_waves_id = user_waves_id
 

--- a/XutheringWavesUID/wutheringwaves_config/config_default.py
+++ b/XutheringWavesUID/wutheringwaves_config/config_default.py
@@ -173,4 +173,10 @@ CONFIG_DEFAULT: Dict[str, GSC] = {
         "验证码提供方appkey",
         "",
     ),
+    "CharCardNum": GsIntConfig(
+        "查看面板图列表，单次转发的图片数量",
+        "查看面板图列表，单次转发的图片数量",
+        5,
+        20,
+    )
 }

--- a/XutheringWavesUID/wutheringwaves_rank/__init__.py
+++ b/XutheringWavesUID/wutheringwaves_rank/__init__.py
@@ -19,7 +19,7 @@ async def send_rank_card(bot: Bot, ev: Event):
     if not ev.group_id:
         return await bot.send("请在群聊中使用")
     
-    char = ev.regex_dict.get("char")
+    char: str = ev.regex_dict.get("char") or ""
 
     rank_type = "伤害"
     if "评分" in char:
@@ -41,7 +41,7 @@ async def send_rank_card(bot: Bot, ev: Event):
 )
 async def send_all_rank_card(bot: Bot, ev: Event):
     
-    char = ev.regex_dict.get("char")
+    char = ev.regex_dict.get("char") or ""
     pages = ev.regex_dict.get("pages")
 
     if pages:

--- a/XutheringWavesUID/wutheringwaves_rank/darw_rank_card.py
+++ b/XutheringWavesUID/wutheringwaves_rank/darw_rank_card.py
@@ -1,3 +1,4 @@
+from PIL.Image import Image
 import asyncio
 import time
 from pathlib import Path

--- a/XutheringWavesUID/wutheringwaves_roleinfo/draw_role_info.py
+++ b/XutheringWavesUID/wutheringwaves_roleinfo/draw_role_info.py
@@ -1,3 +1,4 @@
+from PIL.Image import Image
 from pathlib import Path
 from typing import Optional
 
@@ -106,17 +107,21 @@ async def draw_role_img(uid: str, ck: str, ev: Event):
             {"key": "中型信标", "value": f"{account_info.bigCount}", "info_block": ""},
         ]
 
-        for b in account_info.treasureBoxList:
-            base_info_value_list.append(
-                {"key": b.name, "value": f"{b.num}", "info_block": ""}
-            )
+        if account_info.treasureBoxList is not None:
+            for b in account_info.treasureBoxList:
+                if b is None:
+                    continue
+                base_info_value_list.append(
+                    {"key": b.name, "value": f"{b.num}", "info_block": ""}
+                )
 
     # 初始化基础信息栏位
     bs = Image.open(TEXT_PATH / "bs.png")
 
     # 角色信息
+    roleNum = account_info.roleNum if account_info.roleNum else 0
     roleTotalNum = (
-        account_info.roleNum if account_info.is_full else len(role_info.roleList)
+        roleNum if account_info.is_full else len(role_info.roleList)
     )
     xset = 50
     yset = 470
@@ -125,7 +130,7 @@ async def draw_role_img(uid: str, ck: str, ev: Event):
 
     w = 1000
     h = 100 + yset + 200 * int(roleTotalNum / 4 + (1 if roleTotalNum % 4 else 0))
-    card_img = get_waves_bg(w, h)
+    card_img: Image.Image = get_waves_bg(w, h)
 
     def calc_info_block(_x: int, _y: int, key: str, value: str, color_path: str = ""):
         if not color_path:
@@ -161,6 +166,8 @@ async def draw_role_img(uid: str, ck: str, ev: Event):
         if not role_detail_info_map:
             return
         char_bg = Image.open(TEXT_PATH / "char_bg.png")
+        if roleInfo.attributeName is None:
+            return
         char_attribute = await get_attribute(roleInfo.attributeName)
         char_attribute = char_attribute.resize((40, 40)).convert("RGBA")
         role_avatar = await get_square_avatar(roleInfo.roleId)
@@ -257,5 +264,5 @@ async def draw_role_img(uid: str, ck: str, ev: Event):
     card_img.paste(line2, (0, yset - 70), line2)
 
     card_img = add_footer(card_img, 600, 20)
-    card_img = await convert_img(card_img)
-    return card_img
+    card_img_byte = await convert_img(card_img)
+    return card_img_byte

--- a/XutheringWavesUID/wutheringwaves_stamina/draw_waves_stamina.py
+++ b/XutheringWavesUID/wutheringwaves_stamina/draw_waves_stamina.py
@@ -208,7 +208,7 @@ async def _draw_stamina_img(ev: Event, valid: Dict) -> Image.Image:
         target_w, target_h = 1150, 850
         ratio = max(target_w / bg_w, target_h / bg_h)
         new_size = (int(bg_w * ratio), int(bg_h * ratio))
-        pile = pile.resize(new_size, Image.LANCZOS)
+        pile = pile.resize(new_size, Image.Resampling.LANCZOS)
         
         left = (pile.width - target_w) // 2
         top = (pile.height - target_h) // 2

--- a/XutheringWavesUID/wutheringwaves_wiki/draw_list.py
+++ b/XutheringWavesUID/wutheringwaves_wiki/draw_list.py
@@ -2,6 +2,7 @@ import copy
 import textwrap
 from pathlib import Path
 from collections import defaultdict
+from typing import Any
 from PIL import Image, ImageDraw
 
 from gsuid_core.utils.image.convert import convert_img
@@ -39,7 +40,7 @@ async def draw_weapon_list(weapon_type: str):
         return "[鸣潮][武器列表]暂无数据"
         
     # 武器类型映射
-    weapon_type_map = {
+    weapon_type_map: dict[int, str] = {
         1: "长刃",
         2: "迅刀",
         3: "佩枪",
@@ -53,14 +54,14 @@ async def draw_weapon_list(weapon_type: str):
     logger.debug(f"正在处理武器列表：{reverse_type_map}")
     
     # 按武器类型分组收集武器数据
-    weapon_groups = defaultdict(list)
+    weapon_groups: defaultdict[int, list[dict[str, Any]]] = defaultdict(list)
     target_type = reverse_type_map.get(weapon_type)
     logger.debug(f"成功处理：{target_type}")
     
     for weapon_id, data in weapon_id_data.items():
         name = data.get("name", "未知武器")
         star_level = data.get("starLevel", 0)
-        w_type = data.get("type", 0)  # 注意：避免与参数同名冲突
+        w_type: Any = data.get("type", 0)  # 注意：避免与参数同名冲突
         effect_name = data.get("effectName", "")
         
         # 如果找到目标类型，只收集该类型武器
@@ -82,7 +83,7 @@ async def draw_weapon_list(weapon_type: str):
             })
     
     # 按类型从小到大排序
-    sorted_groups = sorted(weapon_groups.items(), key=lambda x: x[0])
+    sorted_groups= sorted(weapon_groups.items(), key=lambda x: x[0])
     
     # 每行武器数量（单类型4列，全部类型9列）
     weapons_per_row = 9 if target_type is None else 4
@@ -109,9 +110,9 @@ async def draw_weapon_list(weapon_type: str):
     # 绘制武器效果名（灰色）y_offset += 20
     
     # 按武器类型遍历所有分组
-    for weapon_type, weapons in sorted_groups:
+    for wtype, weapons in sorted_groups:
         # 获取类型名称
-        type_name = weapon_type_map.get(weapon_type, f"未知类型{weapon_type}")
+        type_name = weapon_type_map.get(wtype, f"未知类型{wtype}")
         
         # 绘制类型标题
         draw.text((50, y_offset), type_name, font=waves_font_24, fill=SPECIAL_GOLD)


### PR DESCRIPTION
本次更新主要新增了一个配置项，用于控制获取面板图列表时每个转发消息中的图片数量，并优化了部分类型不一致的问题。
具体变更：
   1. 新增配置项：
      - 在配置文件中新增 CharCardNum 配置项，用于设置单次转发消息中包含的面板图数量，默认值为 5，最大可设置为
        20。

English Version
This update mainly adds a configuration option to control the number of images in each forward message when retrieving the character card list, and optimizes some type inconsistency issues.

Changes:
    1. New Configuration Option:
      - Added a CharCardNum configuration option in the config file to set the number of character cards per
        forward message, with a default value of 5 and a maximum of 20.