### PR TITLE
fix: load WuWaCalc implementation on import

### DIFF
--- a/XutheringWavesUID/utils/calc/__init__.py
+++ b/XutheringWavesUID/utils/calc/__init__.py
@@ -9,3 +9,5 @@ def reload_wuwacalc_module():
         globals()["WuWaCalc"] = w
     except ImportError:
         return None
+
+reload_wuwacalc_module()


### PR DESCRIPTION
## Summary
- Load the real `WuWaCalc` implementation when `XutheringWavesUID.utils.calc` is imported.
- Prevent callers that do `from ..utils.calc import WuWaCalc` from receiving the placeholder class.

## Why
Several call sites instantiate `WuWaCalc(role_detail, enemy_detail, is_limit=...)`. If `reload_wuwacalc_module()` has not been called before those imports, they get the placeholder `WuWaCalc` class from `utils.calc`, which raises:

```text
TypeError: WuWaCalc() takes no arguments
```

Loading the compiled implementation during module import keeps existing call sites unchanged while ensuring `WuWaCalc` points to the actual calculator when available.

## Testing
- Verified in a running GSUID Core/XutheringWavesUID environment that importing `WuWaCalc` from `XutheringWavesUID.utils.calc` resolves to the compiled implementation and exposes the expected constructor signature:

```text
(role_detail, enemy_detail=None, is_limit=False)
```

- Restarted GSUID Core successfully after applying the patch; WebSocket clients reconnected normally.
