### PR TITLE
修复抽卡导入重复记录被误删

### DIFF
--- a/XutheringWavesUID/wutheringwaves_gachalog/get_gachalogs.py
+++ b/XutheringWavesUID/wutheringwaves_gachalog/get_gachalogs.py
@@ -87,14 +87,17 @@ def find_longest_common_subarray_indices(
 def merge_gacha_logs_by_common_subarray(a: List[GachaLog], b: List[GachaLog]) -> List[GachaLog]:
     common_indices = find_longest_common_subarray_indices(a, b)
     if not common_indices:
-        # 无公共子串：a/b 两侧均无 match_key 相等的元素，但任一侧自身可能含重复，按 match_key 保序去重
-        seen = set()
+        # 无公共子串：保留单侧内部的重复抽数，只合并两侧之间的重叠记录。
+        target_counts = Counter(log.match_key() for log in a) | Counter(
+            log.match_key() for log in b
+        )
+        used_counts = Counter()
         merged = []
         for log in a + b:
             key = log.match_key()
-            if key in seen:
+            if used_counts[key] >= target_counts[key]:
                 continue
-            seen.add(key)
+            used_counts[key] += 1
             merged.append(log)
         return sorted(
             merged,


### PR DESCRIPTION
## 说明

修复文件导入抽卡记录时，同一来源内部的重复抽数被误删的问题。

鸣潮抽卡记录以秒为时间精度，十连中可能出现同一秒、同物品、同品质的多条记录。原逻辑在没有公共子串时使用 `match_key` 全局去重，会把这些合法重复项压成一条，导致总抽数和五星间隔偏小。

## 改动

- 无公共子串合并时，保留单侧内部重复记录
- 只按两侧出现次数的最大值合并重叠记录，避免重复导入翻倍

## 验证

- `python3 -m py_compile XutheringWavesUID/wutheringwaves_gachalog/get_gachalogs.py`
- 使用同键 1 条/2 条记录的小样例验证合并后保留 2 条
