### PR TITLE
🐛 修复小黑盒导入 heybox_id 位数限制

### DIFF
--- a/XutheringWavesUID/wutheringwaves_gachalog/__init__.py
+++ b/XutheringWavesUID/wutheringwaves_gachalog/__init__.py
@@ -287,10 +287,10 @@ async def get_gacha_log_by_xhh(bot: Bot, ev: Event):
     if not uid:
         return await bot.send(ERROR_CODE[WAVES_CODE_103])
 
-    heybox_id = _parse_import_uid(ev.text)
+    heybox_id = ev.text.strip()
     if not heybox_id:
         return await bot.send(
-            f"请带上UID，例如：{PREFIX}导入小黑盒抽卡记录123456789"
+            f"请带上小黑盒ID，例如：{PREFIX}导入小黑盒抽卡记录12345678"
         )
 
     if not gacha_import_lock.acquire(f"{ev.user_id}_{uid}"):


### PR DESCRIPTION
## Summary

- 小黑盒 `heybox_id` 不是固定9位数字，原代码复用了鸣潮UID的 `\d{9}` 正则校验，导致8位等非9位ID无法通过 `_parse_import_uid` 校验，用户输入后直接报错"请带上UID"
- 将小黑盒导入的参数解析从 `_parse_import_uid(ev.text)` 改为 `ev.text.strip()`，不再限制位数
- 错误提示从"请带上UID"改为"请带上小黑盒ID"，示例从9位改为8位

## Test plan

- [x] 本地测试：8位 heybox_id 可正常导入
- [ ] 验证9位 heybox_id 仍然正常工作

🤖 Generated with [Claude Code](https://claude.com/claude-code)
via [Happy](https://happy.engineering)