### PR TITLE
修正小黑盒抽卡记录导入提示文案

### DIFF
--- a/XutheringWavesUID/wutheringwaves_gachalog/__init__.py
+++ b/XutheringWavesUID/wutheringwaves_gachalog/__init__.py
@@ -52,7 +52,7 @@ sv_gacha_web = SV("waves抽卡网页")
 ERROR_MSG_NOTIFY = f"请给出正确的抽卡记录链接, 可发送【{PREFIX}抽卡帮助】"
 ERROR_MSG_IMPORT_TYPE = (
     "请指定导入类型，支持的方式：\n"
-    f"{PREFIX}导入工坊抽卡记录+uid（9位数字UID）\n"
+    f"{PREFIX}导入工坊抽卡记录+uid\n"
     f"{PREFIX}导入小黑盒抽卡记录+小黑盒ID\n"
     "请将【+uid】替换为对应的9位数字UID，或将【+小黑盒ID】替换为对应的小黑盒ID"
 )

--- a/XutheringWavesUID/wutheringwaves_gachalog/__init__.py
+++ b/XutheringWavesUID/wutheringwaves_gachalog/__init__.py
@@ -52,9 +52,9 @@ sv_gacha_web = SV("waves抽卡网页")
 ERROR_MSG_NOTIFY = f"请给出正确的抽卡记录链接, 可发送【{PREFIX}抽卡帮助】"
 ERROR_MSG_IMPORT_TYPE = (
     "请指定导入类型，支持的方式：\n"
-    f"{PREFIX}导入工坊抽卡记录+uid\n"
-    f"{PREFIX}导入小黑盒抽卡记录+uid\n"
-    "请将【+uid】替换为对应的9位数字UID"
+    f"{PREFIX}导入工坊抽卡记录+uid（9位数字UID）\n"
+    f"{PREFIX}导入小黑盒抽卡记录+小黑盒ID\n"
+    "请将【+uid】替换为对应的9位数字UID，或将【+小黑盒ID】替换为对应的小黑盒ID"
 )
 IMPORT_UID_RE = re.compile(r"^\s*\+?\s*(\d{9})\s*$")
 


### PR DESCRIPTION
## 说明

修正导入类型错误提示中小黑盒抽卡记录参数说明。

原提示将工坊 UID 和小黑盒 ID 都写成 `+uid`，且统一说明为 9 位数字 UID。实际小黑盒导入应填写小黑盒 ID，因此拆分两种导入方式的参数说明。